### PR TITLE
Termux

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,8 +9,11 @@ INSTALL=install
 BUNDLE=bundle
 
 PROG=edam
-
-INSTALLD=/usr/local
+ifeq ($(PREFIX),)
+    INSTALLD=/usr/local
+else
+    INSTALLD=$(PREFIX)
+endif
 BINDIR=$(INSTALLD)/bin
 MANDIR=$(INSTALLD)/share/man/man
 

--- a/README.md
+++ b/README.md
@@ -33,10 +33,11 @@ Building and installing _Edam_ should be as easy as:
 
     make clean && make && make install
 
-Installation is into `/usr/local/bin`. The `edam` binary is
-self-contained, and can be moved anywhere. The manpage is
-installed to `/usr/local/share/man/man1`. The `sedam` script
-and its manpage are also installed.
+Installation is into `$PREFIX/bin` or `/usr/local/bin` if `$PREFIX` 
+is not defined. The `edam` binary is self-contained, and can be
+moved anywhere. The manpage is installed to
+`$PREFIX/share/man/man1`. The `sedam` script and its manpage
+are also installed.
 
 To uninstall, `make uninstall`.
 

--- a/README.md
+++ b/README.md
@@ -33,9 +33,9 @@ Building and installing _Edam_ should be as easy as:
 
     make clean && make && make install
 
-Installation is into `$PREFIX/bin` or `/usr/local/bin` if `$PREFIX` 
-is not defined. The `edam` binary is self-contained, and can be
-moved anywhere. The manpage is installed to
+Installation is into `$PREFIX/bin`, or to `/usr/local/bin` if
+`$PREFIX` is not defined. The `edam` binary is self-contained,
+and can be moved anywhere. The manpage is installed to
 `$PREFIX/share/man/man1`. The `sedam` script and its manpage
 are also installed.
 

--- a/disc.c
+++ b/disc.c
@@ -3,8 +3,10 @@
 #include "edam.h"
 
 static Discdesc desc[NBUFFILES];
-static char tempfname[30];
+static char tempfname[64];
 static int inited=0;
+
+extern char *tmpdir;
 
 void Dremove(void);
 Discdesc * Dstart(void);
@@ -26,7 +28,7 @@ Dremove(void)
    int i;
    Discdesc *dd;
    for(i=0, dd=desc; dd->fd; i++, dd++){
-      sprintf(tempfname, "/tmp/edam%d.%d", getpid(), i);
+      sprintf(tempfname, "%s/edam%d.%d", tmpdir, getpid(), i);
       unlink(tempfname);
    }
 }
@@ -39,7 +41,7 @@ Dstart(void)
    for(i=0, dd=desc; dd->fd; i++, dd++)
       if(i==NBUFFILES-1)
          panic("too many buffer files");
-   sprintf(tempfname, "/tmp/edam%d.%d", getpid(), i);
+   sprintf(tempfname, "%s/edam%d.%d", tmpdir, getpid(), i);
    fd=open(tempfname, O_CREAT | O_TRUNC | O_WRONLY, 0600);
    if(fd<0){
       unlink(tempfname);

--- a/disc.c
+++ b/disc.c
@@ -3,7 +3,7 @@
 #include "edam.h"
 
 static Discdesc desc[NBUFFILES];
-static char tempfname[30];
+static char tempfname[64];
 static int inited=0;
 
 extern char *tmpdir;

--- a/disc.c
+++ b/disc.c
@@ -6,6 +6,8 @@ static Discdesc desc[NBUFFILES];
 static char tempfname[30];
 static int inited=0;
 
+extern char *tmpdir;
+
 void Dremove(void);
 Discdesc * Dstart(void);
 void Dclosefd(void);
@@ -26,7 +28,7 @@ Dremove(void)
    int i;
    Discdesc *dd;
    for(i=0, dd=desc; dd->fd; i++, dd++){
-      sprintf(tempfname, "/tmp/edam%d.%d", getpid(), i);
+      sprintf(tempfname, "%s/edam%d.%d", tmpdir, getpid(), i);
       unlink(tempfname);
    }
 }
@@ -39,7 +41,7 @@ Dstart(void)
    for(i=0, dd=desc; dd->fd; i++, dd++)
       if(i==NBUFFILES-1)
          panic("too many buffer files");
-   sprintf(tempfname, "/tmp/edam%d.%d", getpid(), i);
+   sprintf(tempfname, "%s/edam%d.%d", tmpdir, getpid(), i);
    fd=open(tempfname, O_CREAT | O_TRUNC | O_WRONLY, 0600);
    if(fd<0){
       unlink(tempfname);

--- a/edam.c
+++ b/edam.c
@@ -11,6 +11,7 @@ typedef struct Patlist{
 }Patlist;
 
 char genbuf[BLOCKSIZE];
+char *tmpdir;
 char *home;
 int io;
 int panicking;
@@ -97,6 +98,9 @@ panic("|Posn| != |long*|");
    home=getenv("HOME");
    if(home==0)
       home="/tmp";
+   tmpdir=getenv("TMPDIR");
+   if (tmpdir==0) 
+      tmpdir="/tmp";
    if(argc>1){
       for(i=1; i<argc; i++)
 {

--- a/edam.c
+++ b/edam.c
@@ -101,9 +101,6 @@ panic("|Posn| != |long*|");
    home=getenv("HOME");
    if(home==0)
       home="/tmp";
-   tmpdir=getenv("TMPDIR");
-   if (tmpdir==0) 
-      tmpdir="/tmp";
    if(argc>1){
       for(i=1; i<argc; i++)
 {

--- a/edam.c
+++ b/edam.c
@@ -83,6 +83,9 @@ panic("|Posn| != |long*|");
       }
       --argc, argv++;
    }
+   tmpdir=getenv("TMPDIR");
+   if (tmpdir==0) 
+      tmpdir="/tmp";
    Fstart();
    strinit(&cmdstr);
    strinit(&lastpat);

--- a/edam.c
+++ b/edam.c
@@ -11,6 +11,7 @@ typedef struct Patlist{
 }Patlist;
 
 char genbuf[BLOCKSIZE];
+char *tmpdir;
 char *home;
 int io;
 int panicking;
@@ -82,6 +83,9 @@ panic("|Posn| != |long*|");
       }
       --argc, argv++;
    }
+   tmpdir=getenv("TMPDIR");
+   if (tmpdir==0) 
+      tmpdir="/tmp";
    Fstart();
    strinit(&cmdstr);
    strinit(&lastpat);


### PR DESCRIPTION
Hi! 

/tmp is not writable in the Termux environment on Android; the standard tmp directory is somewhere else (/data/data/com.termux/files/usr/tmp), so edam compiles on Termux, but fails right away with "can't create buffer file".

This is my first attempt at this sort of thing, and I don't know the etiquette, and am not a C programmer, and my commit history is a bit of a mess, so if there is anything I can change, please say so, or just tell me if I'm doing the wrong thing entirely. But it does install and seems to work on Termux with these changes.

- Removed hard-coded "/tmp" when allocating temp files and read $TMPDIR instead, or fallback to /tmp
- Similarly, in Makefile look for $PREFIX and if it is there, use that to define INSTALLD, otherwise fallback to /usr/local
- Update README